### PR TITLE
Remove build from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,3 @@ jobs:
       run: npm run lint
     - name: Run Jest tests
       run: npm run test
-    - name: Build app
-      run: npm run build --if-present
-    


### PR DESCRIPTION
I removed the "build" step from the GitHub action to speed it up since we're not relying on it currently for deployment. It currently saves approximately 30 seconds, and that savings will increase the application grows and takes longer to build. 

We can discuss whether or not it'll be needed in the future once we figure out where our app will be deployed.