### PR TITLE
Downgrade Postgres version to match Heroku

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   db:
-    image: postgres:14.0
+    image: postgres:13.5
     restart: always
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"


### PR DESCRIPTION
Heroku uses Postgres version 13.5, so this will downgrade the version used by Docker to match it.